### PR TITLE
Adicionado CNI-plugins ao nomad

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@
 nomad_version: "1.1.2"
 nomad_user: nomad
 nomad_group: nomad
+# nomad-cni-plugins
+nomad_cni_version: '1.0.0'
+nomad_cni_url: "https://github.com/containernetworking/plugins/releases/download/v{{ nomad_cni_version }}/cni-plugins-linux-amd64-v{{nomad_cni_version }}.tgz"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -41,5 +41,7 @@ galaxy_info:
 
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+  # if you add dependencies to this list. 
 
+collections:
+  - ansible.posix

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -71,8 +71,6 @@
         - client.hcl.j2
         - server.hcl.j2
       register: nomad_config_file_content
-    - debug:
-        msg: "{{ nomad_config_file_content.results[0] }}"
     - name: "Verificar conteúdo do arquivo de configuração do client"
       assert:
         that:
@@ -89,4 +87,23 @@
           - nomad_data_dir_output.stat.isdir
           - "nomad_data_dir_output.stat.gr_name == '{{nomad_group}}'"
           - "nomad_data_dir_output.stat.pw_name == '{{nomad_user}}'"
+    - name: "Ler CNI-plugin"
+      stat:
+        path: /opt/cni/bin/bridge
+      register: nomad_cni_plugin_output
+    - name: " Verificar cni-plugin"
+      assert:
+        that:
+          - nomad_cni_plugin_output.stat.exists
+          - nomad_cni_plugin_output.stat.mode == '0755'
+    - name: "Ler conteúdo do arquivo de configuração 10-net-bridge.conf"
+      slurp:
+        src: "/etc/sysctl.d/10-net-bridge.conf"
+      register: nomad_net_bridge_content
+    - name: "Verificar conteúdo do arquivo de configuração do 10-net-bridge"
+      assert:
+        that:
+          - "{{ nomad_net_bridge_content.content | b64decode | regex_search('net.bridge.bridge-nf-call-arptables\\s*=\\s*1') | length }} > 0"
+          - "{{ nomad_net_bridge_content.content | b64decode | regex_search('net.bridge.bridge-nf-call-ip6tables\\s*=\\s*1') | length }} > 0"
+          - "{{ nomad_net_bridge_content.content | b64decode | regex_search('net.bridge.bridge-nf-call-iptables\\s*=\\s*1') | length }} > 0"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,3 +31,25 @@
     - client.hcl.j2
     - server.hcl.j2
 
+# CNI-plugin
+
+- name: " Criando Diretorio para os plugins-CNI"
+  ansible.builtin.file:
+    path: /opt/cni/bin
+    state: directory
+- name: "CNI-plugin | unarchive"
+  ansible.builtin.unarchive:
+    src: "{{ nomad_cni_url }}"
+    dest: /opt/cni/bin
+    creates: /opt/cni/bin/bridge
+    remote_src: yes
+    mode: '0755'
+- name: " CNI sysctl"
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    value: "1"
+    sysctl_file: /etc/sysctl.d/10-net-bridge.conf
+  loop:
+    - "net.bridge.bridge-nf-call-arptables"
+    - "net.bridge.bridge-nf-call-ip6tables"
+    - "net.bridge.bridge-nf-call-iptables"


### PR DESCRIPTION
Instalando CNI-plugins para Nomad


- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue 

closes https://github.com/mentoriaiac/iac-role-nomad/issues/3

## Objetivo

O Nomad usa plug-ins CNI para configurar o namespace de rede usado para proteger o proxy secundário do Consul Connect. Todos os nós clientes Nomad usando namespaces de rede devem ter plug-ins CNI instalados.

## Referências

https://www.nomadproject.io/docs/integrations/consul-connect#cni-plugins

## Como testar

Teste realizados com molecule

<!--
Marque um `x` dentro de [ ] para os itens que você forneceu informação
Para modificar este template no seu repositório, basta criar o arquivo .github/pull_request_template.md nele.
-->
