### PR TITLE
fix: Arrumando o script de bootstrap para ler os parâmetros corretamente

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Run Linters
         run: |
           ansible-lint
+          shellcheck ./templates/nomad_bootstrap.sh
   molecule:
     runs-on: ubuntu-18.04
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ O formato é baseado no [Mantenha um Changelog](https://keepachangelog.com/pt-BR
 e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/spec/v2.0.0.html).
 
 ## [Não publicado]
+### Corrigido
+- Corrigido problemas ao ler atributos do script de bootstrap [[GH-8](https://github.com/mentoriaiac/iac-role-nomad/pull/8)]
 
 ## [0.1.0] - 2021-09-04
 ### Adicionado

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -1,7 +1,7 @@
 {% include "nomad.hcl.j2" %}
 
 client {
-  enabled = <CLIENT_ENABLED>
+  enabled = true
 
   server_join {
     retry_join = [<RETRY_JOIN>]

--- a/templates/nomad_bootstrap.sh
+++ b/templates/nomad_bootstrap.sh
@@ -71,7 +71,6 @@ render_server_config() {
   fi
 
   sed --expression "
-    s/<SERVER_ENABLED>/true/
     s/<BOOTSTRAP_EXPECT>/${bootstrap_expect}/
     s/<RETRY_JOIN>/${retry_join}/
   " "${nomad_config_path}/server.hcl.tpl" > "${nomad_config_path}/server.hcl"
@@ -83,7 +82,6 @@ render_client_config() {
   echo "Renderizando arquivo de configuração do client..."
 
   sed --expression "
-    s/<CLIENT_ENABLED>/true/
     s/<RETRY_JOIN>/${retry_join}/
   " "${nomad_config_path}/client.hcl.tpl" > "${nomad_config_path}/client.hcl"
 }

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -1,7 +1,7 @@
 {% include "nomad.hcl.j2" %}
 
 server {
-  enabled          = <SERVER_ENABLED>
+  enabled          = true
   bootstrap_expect = <BOOTSTRAP_EXPECT>
 
   server_join {


### PR DESCRIPTION
# fix: Arrumando o script de bootstrap para ler os parâmetros corretamente

O script de bootstrap não estava lidando com os parâmetros de entrada corretamente. Sem as aspas em torno das variáveis, entradas com espaço, como o `retry_join`, estavam sendo processadas de forma incompleta.

Esse PR coloca aspas em tornos das variáveis e também adiciona o [`shellcheck`](https://www.shellcheck.net/) como linter no CI para evitar esses tipos de problemas no futuro.

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Corrigir o script de bootstrap.

## Referências

- https://www.shellcheck.net/
- https://tldp.org/LDP/abs/html/quotingvar.html

## Como testar

Em um terminal na pasta raiz do projeto, rodar:
```console
$ molecule converge
$ molecule login
```

Dentro do terminal do molecule, rodar:

```console
root@ubuntu-20-04-iac-role-nomad:/# /usr/local/bin/nomad_bootstrap.sh both 1 '\"10.0.0.1\", \"10.0.0.2\"'
root@ubuntu-20-04-iac-role-nomad:/# cat /etc/nomad.d/{client,server}.hcl
```

Verificar que a saída é a esperada:

```hcl
data_dir  = "/opt/nomad/data"
bind_addr = "0.0.0.0" # the default
client {
  enabled = true

  server_join {
    retry_join = ["10.0.0.1", "10.0.0.2"]
  }
}
data_dir  = "/opt/nomad/data"
bind_addr = "0.0.0.0" # the default
server {
  enabled          = true
  bootstrap_expect = 1

  server_join {
    retry_join = ["10.0.0.1", "10.0.0.2"]
  }
}
```