### PR TITLE
feat: Adicionada configuração de habiliar ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 
 ## [Não publicado]
 ### Adicionado
-- Configuração para habilitar o sistema de ACL  [[GH-13](https://github.com/mentoriaiac/iac-role-nomad/pull/13)]
+- Configuração para habilitar o sistema de ACL  [[GH-13](https://github.com/mentoriaiac/iac_role_nomad/pull/13)]
 
 ### Corrigido
-- Corrigido problemas ao ler atributos do script de bootstrap [[GH-8](https://github.com/mentoriaiac/iac-role-nomad/pull/8)]
+- Corrigido problemas ao ler atributos do script de bootstrap [[GH-8](https://github.com/mentoriaiac/iac_role_nomad/pull/8)]
 
 ## [0.1.0] - 2021-09-04
 ### Adicionado
-- Instalação, configuração e testes do pacote do Nomad [[GH-2](https://github.com/mentoriaiac/iac-role-nomad/pull/2)]
-- Instalação dos plugins de CNI [[GH-5](https://github.com/mentoriaiac/iac-role-nomad/pull/5)]
-- Script de inicialização da imagem [[GH-6](https://github.com/mentoriaiac/iac-role-nomad/pull/6)]
+- Instalação, configuração e testes do pacote do Nomad [[GH-2](https://github.com/mentoriaiac/iac_role_nomad/pull/2)]
+- Instalação dos plugins de CNI [[GH-5](https://github.com/mentoriaiac/iac_role_nomad/pull/5)]
+- Script de inicialização da imagem [[GH-6](https://github.com/mentoriaiac/iac_role_nomad/pull/6)]
 
 
-[Não publicado]: https://github.com/mentoriaiac/iac-role-nomad/compare/0.1.0...HEAD
-[0.1.0]: https://github.com/mentoriaiac/iac-role-nomad/releases/tag/0.1.0
+[Não publicado]: https://github.com/mentoriaiac/iac_role_nomad/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/mentoriaiac/iac_role_nomad/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ O formato é baseado no [Mantenha um Changelog](https://keepachangelog.com/pt-BR
 e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/spec/v2.0.0.html).
 
 ## [Não publicado]
+### Adicionado
+- Configuração para habilitar o sistema de ACL  [[GH-13](https://github.com/mentoriaiac/iac-role-nomad/pull/13)]
+
 ### Corrigido
 - Corrigido problemas ao ler atributos do script de bootstrap [[GH-8](https://github.com/mentoriaiac/iac-role-nomad/pull/8)]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Template Role Ansible
 
-![Pipeline Status](https://github.com/mentoriaiac/iac-role-nomad/actions/workflows/ci.yml/badge.svg) 
+![Pipeline Status](https://github.com/mentoriaiac/iac_role_nomad/actions/workflows/ci.yml/badge.svg) 
 
 Esse projeto tem a finalidade de ser uma Role Ansible para instalar o Nomad.
 
@@ -16,11 +16,11 @@ Para realizar os teste localmente é necessário a instalação das seguintes de
 ### Primeiro Passo:
 
 Clone este repositório, ele é a base da role do nomad.
-> git clone https://github.com/mentoria/iac-role-nomad
+> git clone https://github.com/mentoria/iac_role_nomad
 
 
 Ao final um diretório com a sua role será criado e você precisa agora entrar neste novo diretório. Para fazer isto use o comando a seguir:
-> cd iac-role-nomad
+> cd iac_role_nomad
 
 
 ### Segundo Passo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,11 @@
 ---
-# defaults file for iac-role-nomad
 nomad_version: "1.1.2"
 nomad_user: nomad
 nomad_group: nomad
+
 # nomad-cni-plugins
-nomad_cni_version: '1.0.0'
+nomad_cni_version: "1.0.0"
 nomad_cni_url: "https://github.com/containernetworking/plugins/releases/download/v{{ nomad_cni_version }}/cni-plugins-linux-amd64-v{{nomad_cni_version }}.tgz"
+
+# Configurações de ACL
+nomad_acl_enabled: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for iac-role-nomad
+# handlers file for iac_role_nomad

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,6 @@
         name: gnupg2
         state: present
 
-    - name: "Include iac-role-nomad"
+    - name: "Include iac_role_nomad"
       include_role:
-        name: "iac-role-nomad"
+        name: "iac_role_nomad"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ubuntu-20-04-iac-role-nomad
+  - name: ubuntu-20-04-iac_role_nomad
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,6 +6,7 @@
   gather_facts: false
   vars_files:
     - ../../defaults/main.yml
+    - ../../vars/main.yml
   tasks:
     - name: "Roda um comando do Nomad"
       command: "nomad -version"
@@ -74,7 +75,13 @@
     - name: "Verificar conteúdo do arquivo de configuração do client"
       assert:
         that:
-          - "{{ nomad_config_file_content.results[0]['content'] | b64decode | regex_search('data_dir\\s+=\\s+\".+\"') | length }} > 0"
+          # Verificando que a configuração de data_dir está presente.
+          - "{{ nomad_config_file_content.results[0]['content'] | b64decode | regex_search(data_dir_regex) | length }} > 0"
+          # Verificando que a configuração de ACL está presente e com o valor correto.
+          - "{{ nomad_config_file_content.results[0]['content'] | b64decode | regex_search(acl_enabled_regex) | length }} > 0"
+      vars:
+        data_dir_regex: 'data_dir\s+=\s+".+"'
+        acl_enabled_regex: "acl\\s+{\\s+enabled\\s+=\\s+{{ nomad_acl_enabled_str }}"
 
     - name: "Ler data_dir do Nomad"
       stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for iac-role-nomad
+# tasks file for iac_role_nomad
 - name: "Adicionando chave apt da HashiCorp"
   apt_key:
     url: https://apt.releases.hashicorp.com/gpg

--- a/templates/nomad.hcl.j2
+++ b/templates/nomad.hcl.j2
@@ -1,2 +1,6 @@
 data_dir  = "/opt/nomad/data"
 bind_addr = "0.0.0.0" # the default
+
+acl {
+  enabled = {{ nomad_acl_enabled_str }}
+}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - iac-role-nomad
+    - iac_role_nomad

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
-# vars file for iac-role-nomad
+# nomad_acl_enabled_str sobrescreve a variável nomad_acl_enabled como uma string
+# com valor "true" ou "false" para evitar problemas com o tipo booleano do YAML.
+nomad_acl_enabled_str: "{{ nomad_acl_enabled | ternary('true', 'false') }}"


### PR DESCRIPTION
# Adicionada configuração de habiliar ACL

O sistema de ACL permite relizar o controle de acesso ao cluster do
Nomad. Por ser uma configuração de segurança, é recomendável habiliar em
sistema de produção.

A configuração pode ser controlada pela variável do role `nomad_acl_enabled`.

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

Closes #10 

## Objetivo

Habilitar o sistema de ACL do Nomad

## Referências

- https://learn.hashicorp.com/tutorials/nomad/access-control-bootstrap?in=nomad/access-control#enable-acls-on-nomad-servers
- https://learn.hashicorp.com/tutorials/nomad/access-control-bootstrap?in=nomad/access-control#enable-acls-on-nomad-clients

## Como testar

O PR adiciona testes para validar que a configuração de ACL é adicionada aos arquivos finais, então basta rodar os testes com o `molecule`:

```console
$ molecule test
```
