### PR TITLE
Atualizando versão do Nomad para 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 - Configuração para telemetry e raft_protocol [[GH-23](https://github.com/mentoriaiac/iac_role_nomad/pull/23)]
 - Configuração para region e datacenter [[GH-24](https://github.com/mentoriaiac/iac_role_nomad/pull/24)]
 
+### Modificado
+- Atualizando a versão padrão do Nomad para 1.3.1 [[GH-26](https://github.com/mentoriaiac/iac_role_nomad/pull/26)]
+
+
 ## [0.3.0] - 2021-09-08
 ### Adicionado
 - Usar role de runtime [[GH-15]](https://github.com/mentoriaiac/iac_role_nomad/pull/15)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nomad_version: "1.3.1-1"
+nomad_version: "1.3.1"
 nomad_user: nomad
 nomad_group: nomad
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nomad_version: "1.1.2"
+nomad_version: "1.3.1-1"
 nomad_user: nomad
 nomad_group: nomad
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 nomad_version: "1.3.1"
+nomad_package_version: "1"
 nomad_user: nomad
 nomad_group: nomad
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     update_cache: yes
 - name: "Instalando Nomad"
   apt:
-    name: "nomad={{ nomad_version }}"
+    name: "nomad={{ nomad_version }}-1"
     state: present
 - name: "Removendo arquivos padrão de exemplo"
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     update_cache: yes
 - name: "Instalando Nomad"
   apt:
-    name: "nomad={{ nomad_version }}-1"
+    name: "nomad={{ nomad_version }}-{{ nomad_package_version }}"
     state: present
 - name: "Removendo arquivos padrão de exemplo"
   file:


### PR DESCRIPTION
# Atualização de Versão do Nomad para 1.3.1

Co-authored-by: Luiz Aoqui <lgfa29@gmail.com>
Co-authored-by: Edemir Toldo <edemirtoldo@gmail.com>
Co-authored-by: Danilo F Rocha <snifbr@gmail.com>
Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

#25 

## Objetivo

Atualizar a versão do Nomad, para obter novos recursos das versões mais recentes, e corrigir a [CVE-2022-30324](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30324).

## Referências

https://github.com/hashicorp/nomad/releases/tag/v1.3.1
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30324

## Como testar

<!-- Passo a passo -->

Com o clone do repositório em seu computador, e com os requisitos já instalados (Python 3 + Docker + PIP + Venv), instale as ferramentas com o comando `pip install -r requeriments.txt` em sua virtualenv. Após instalar, execute o molecule com o comando `molecule test`. 
