### PR TITLE
fix: cria a pasta para armezenar arquivos de mTLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 mol-venv/
 .cache/
+.venv/
+
+Vagrantfile
+.vagrant/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 ### Modificado
 - Atualizando a versão padrão do Nomad para 1.3.1 [[GH-26](https://github.com/mentoriaiac/iac_role_nomad/pull/26)]
 
+### Corrigido
+- Criação da pasta para chaves e certificados mTLS [[GH-29](https://github.com/mentoriaiac/iac_role_nomad/pull/29)]
 
 ## [0.3.0] - 2021-09-08
 ### Adicionado

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ nomad_cni_url: "https://github.com/containernetworking/plugins/releases/download
 
 # Configurações de ACL
 nomad_acl_enabled: true
+nomad_mtls_enabled: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,4 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: all
   gather_facts: false
@@ -17,17 +15,25 @@
           - nomad_version_output.rc == 0
           - "'{{nomad_version}}' in nomad_version_output.stdout"
 
-    - name: "Ler diretório de configuração do Nomad"
+    - name: "Ler diretórios de configuração do Nomad"
       stat:
-        path: /etc/nomad.d/
+        path: "{{item}}"
+      loop:
+        - /etc/nomad.d/
+        - /etc/nomad.d/certs/
       register: nomad_config_dir_output
-    - name: "Verificar o diretório de configuração do Nomad"
+    - name: "Verificar os diretórios de configuração do Nomad"
       assert:
         that:
-          - nomad_config_dir_output.stat.exists
-          - nomad_config_dir_output.stat.isdir
-          - "nomad_config_dir_output.stat.pw_name == '{{nomad_user}}'"
-          - "nomad_config_dir_output.stat.gr_name == '{{nomad_group}}'"
+          - "nomad_config_dir_output.results[{{index}}].stat.exists"
+          - "nomad_config_dir_output.results[{{index}}].stat.isdir"
+          - "nomad_config_dir_output.results[{{index}}].stat.pw_name == '{{nomad_user}}'"
+          - "nomad_config_dir_output.results[{{index}}].stat.gr_name == '{{nomad_group}}'"
+      loop:
+        - /etc/nomad.d/
+        - /etc/nomad.d/certs/
+      loop_control:
+        index_var: index
 
     - name: "Ler arquivos padrão de configuração do Nomad"
       stat:
@@ -84,14 +90,11 @@
           # Verificando que a configuração de telemetry está presente.
           - "{{ nomad_config_file_content.results[0]['content'] | b64decode | regex_search(telemetry_regex, multiline=True) | length }} > 0"
           - "{{ nomad_config_file_content.results[1]['content'] | b64decode | regex_search(telemetry_regex, multiline=True) | length }} > 0"
-          # Verificando que a configuração de raft_protocol está presente e com valor correto.
-          - "{{ nomad_config_file_content.results[1]['content'] | b64decode | regex_search(raft_protocol_regex, multiline=True) | length }} > 0"
 
       vars:
         data_dir_regex: '^data_dir\s+=\s+".+"'
         acl_enabled_regex: "^acl\\s+{\\s+enabled\\s+=\\s+{{ nomad_acl_enabled_str }}"
         telemetry_regex: '^telemetry\s+{\s+'
-        raft_protocol_regex: '^\s*raft_protocol\s+=\s+3'
 
     - name: "Ler data_dir do Nomad"
       stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for iac_role_nomad
+# Instalação
 - name: "Adicionando chave apt da HashiCorp"
   apt_key:
     url: https://apt.releases.hashicorp.com/gpg
@@ -13,6 +13,8 @@
   apt:
     name: "nomad={{ nomad_version }}-{{ nomad_package_version }}"
     state: present
+
+# Configuração
 - name: "Removendo arquivos padrão de exemplo"
   file:
     path: "/etc/nomad.d/{{ item }}"
@@ -29,19 +31,25 @@
   loop:
     - client.hcl
     - server.hcl
+- name: "Criando diretório dos certificados de mTLS"
+  file:
+    path: "/etc/nomad.d/certs/"
+    state: directory
+    owner: "{{ nomad_user }}"
+    group: "{{ nomad_group }}"
+    mode: 0700
 - name: "Criando script de inicialização"
   template:
     src: nomad_bootstrap.sh
     dest: /usr/local/bin/nomad_bootstrap.sh
     mode: 0755
 
-# CNI-plugin
-
-- name: "Criando Diretorio para os plugins-CNI"
+# Plugins CNI
+- name: "Criando Diretorio para os plugins CNI"
   ansible.builtin.file:
     path: /opt/cni/bin
     state: directory
-- name: "CNI-plugin | unarchive"
+- name: "Download dos plugins CNI"
   ansible.builtin.unarchive:
     src: "{{ nomad_cni_url }}"
     dest: /opt/cni/bin

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -8,12 +8,16 @@ client {
   }
 }
 
+{% if nomad_mtls_enabled  %}
 tls {
-  ca_file                = "/etc/nomad.d/certs/nomad-ca.pem"
-  cert_file              = "/etc/nomad.d/certs/client.pem"
-  key_file               = "/etc/nomad.d/certs/client-key.pem"
-  http                   = true
-  rpc                    = true
+  http = true
+  rpc  = true
+
   verify_https_client    = true
   verify_server_hostname = true
+
+  ca_file   = "/etc/nomad.d/certs/nomad-ca.pem"
+  cert_file = "/etc/nomad.d/certs/client.pem"
+  key_file  = "/etc/nomad.d/certs/client-key.pem"
 }
+{% endif %}

--- a/templates/nomad.hcl.j2
+++ b/templates/nomad.hcl.j2
@@ -1,7 +1,7 @@
 data_dir  = "/opt/nomad/data"
 bind_addr = "0.0.0.0" # the default
 
-region = "<REGION>"
+region     = "<REGION>"
 datacenter = "<DATACENTER>"
 
 acl {

--- a/templates/nomad_bootstrap.sh
+++ b/templates/nomad_bootstrap.sh
@@ -4,7 +4,7 @@ nomad_config_path=/etc/nomad.d
 
 help() {
   echo "
-uso: nomad_boostrap.sh [-h|--help] mode [bootstrap_expect] [rety_join] [region] [datacenter]
+uso: nomad_boostrap.sh [-h|--help] mode [bootstrap_expect] [rety_join] [region] [datacenter] [secrets]
 
 Inicializa os arquivos de configuração do Nomad e habilita a unidade do Nomad no systemd.
 
@@ -15,8 +15,9 @@ argumentos opcionais:
   --help, -h, help       imprime essa mensagem de ajuda.
   bootstrap_expect       número de servidores no cluster.
   retry_join             lista de IPs ou configuração do cloud auto-join.
-  region                 região do agente Nomad 
+  region                 região do agente Nomad
   datacenter             datacenter do agente Nomad
+  secrets                segredos que serão colocados na máquina
 
 exemplos:
   Iniciar cluster local com client e servidor:
@@ -25,6 +26,10 @@ exemplos:
   Iniciar cluster no GCP com cloud auto-join:
     nomad_boostrap.sh server 3 '\"provider=gce project_name=meu-projeto tag_value=nomad-server\"'
     nomad_boostrap.sh client '\"provider=gce project_name=meu-projeto tag_value=nomad-server\"'
+
+  Iniciar cluster configurado com mTLS
+    nomad_boostrap.sh server 3 '\"provider=gce project_name=meu-projeto tag_value=nomad-server\"' global dc1 nomad-ca:1 nomad-server-cert:2 nomad-server-key:1
+    nomad_boostrap.sh client '\"provider=gce project_name=meu-projeto tag_value=nomad-server\"' global dc1 nomad-ca:1 nomad-client-cert:2 nomad-client-key:1
 "
 }
 
@@ -125,6 +130,7 @@ google_secret() {
   local path="$3"
 
   gcloud secrets versions access "$version" --secret="$secret" > "$path"
+  chmod 400 "$path"
 }
 
 main "$@"

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -9,12 +9,16 @@ server {
   }
 }
 
+{% if nomad_mtls_enabled  %}
 tls {
-  ca_file                = "/etc/nomad.d/certs/nomad-ca.pem"
-  cert_file              = "/etc/nomad.d/certs/server.pem"
-  key_file               = "/etc/nomad.d/certs/server-key.pem"
-  http                   = true
-  rpc                    = true
+  http = true
+  rpc  = true
+
   verify_https_client    = true
   verify_server_hostname = true
+
+  ca_file   = "/etc/nomad.d/certs/nomad-ca.pem"
+  cert_file = "/etc/nomad.d/certs/server.pem"
+  key_file  = "/etc/nomad.d/certs/server-key.pem"
 }
+{% endif %}


### PR DESCRIPTION
Um passo que faltou no PR #27 foi criar a pasta onde os certificados e
chaves de mTLS serão armazenados. Também ajusta as permissões da pasta e
dos arquivos para limitar o acesso a apenas ao owner.

Arruma testes que não são mais usados e formata os templates em HCL.

Co-authored-by: Danilo F Rocha <snifbr@gmail.com>
Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>
Co-authored-by: Donato Horn <donatohorn@gmail.com>

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Arrumar um problema onde o script de bootstrap falha porque o diretório para armazenar os arquivos de mTLS não existe.

## Referências

N/A

## Como testar

Em uma máquina Linux, instalar as dependências e rodar `molecule`:

```console
$ python3 -m virtualenv .venv
$ ./venv/bin/activate
$ pip install -r requirements.txt
$ molecule test
```
