### PR TITLE
fix: arrumando permissão da pasta de plugins CNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 ### Adicionado
 - Configuração para telemetry e raft_protocol [[GH-23](https://github.com/mentoriaiac/iac_role_nomad/pull/23)]
 - Configuração para region e datacenter [[GH-24](https://github.com/mentoriaiac/iac_role_nomad/pull/24)]
+- Definição de modo de acesso para a pasta de plugins CNI [[GH-31](https://github.com/mentoriaiac/iac_role_nomad/pull/31)]
 
 ### Modificado
 - Atualizando a versão padrão do Nomad para 1.3.1 [[GH-26](https://github.com/mentoriaiac/iac_role_nomad/pull/26)]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
   ansible.builtin.file:
     path: /opt/cni/bin
     state: directory
+    mode: 0755
 - name: "Download dos plugins CNI"
   ansible.builtin.unarchive:
     src: "{{ nomad_cni_url }}"


### PR DESCRIPTION
Sem definir o parâmetro de `mode` do módulo `file` o linter do
`ansible-lint` indicava o seguinte erro:

```
tasks/main.yml:40: risky-file-permissions File permissions unset or incorrect
Error: risky-file-permissions File permissions unset or incorrect
```

Definindo o modo para 0755 pois não há arquivos confidenciais.

Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>
Co-authored-by: Edemir Toldo <edemirtoldo@gmail.com>
Co-authored-by: Jorge Martins <jorge.martins@gmail.com>
Co-authored-by: Luis Kihara <luiskihara@gmail.com>
Co-authored-by: william dias <will.kof1@gmail.com>
Co-authored-by: Danilo F Rocha <snifbr@gmail.com>

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

Closes #28

## Objetivo

Definir permissão de acesso para a pasta de plugins de CNI para evitar erro no linter.

## Referências

N/A

## Como testar

```
ansible-lint
```
