### PR TITLE
deps: atualizando a versão da role de runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 
 ### Modificado
 - Atualizando a versão padrão do Nomad para 1.3.1 [[GH-26](https://github.com/mentoriaiac/iac_role_nomad/pull/26)]
+- Atualizando versão da role iac_role_runtime para 0.2.0 [[GH-32](https://github.com/mentoriaiac/iac_role_nomad/pull/32)]
 
 ### Corrigido
 - Criação da pasta para chaves e certificados mTLS [[GH-29](https://github.com/mentoriaiac/iac_role_nomad/pull/29)]

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,3 @@
 - name: iac_role_runtime
   src: git+https://github.com/mentoriaiac/iac_role_runtime.git
-  version: v0.1.0
+  version: v0.2.0


### PR DESCRIPTION
Atualizada a versão da role de runtime para v0.2.0 para corrigir
problemas na configuração do Docker daemon e instalar a ferramenta
`kmod`.

Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>
Co-authored-by: Edemir Toldo <edemirtoldo@gmail.com>
Co-authored-by: Jorge Martins <jorge.martins@gmail.com>
Co-authored-by: Luis Kihara <luiskihara@gmail.com>
Co-authored-by: william dias <will.kof1@gmail.com>
Co-authored-by: Danilo F Rocha <snifbr@gmail.com>
Co-authored-by: Donato Horn <donatohorn@gmail.com>


- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

Closes #30

## Objetivo

Atualizar dependências para corrigir bugs.

## Referências

- https://github.com/mentoriaiac/iac_role_runtime/pull/7
- https://github.com/mentoriaiac/iac_role_runtime/pull/9

## Como testar

Rodar o `molecule test`
