### PR TITLE
fix: corrigindo a versão da role iac_role_runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 
 ## [Não publicado]
 
+### Corrigido
+
+- Atualizando versão da role iac_role_runtime para 0.2.0 no `meta/main.yml` [[GH-33](https://github.com/mentoriaiac/iac_role_nomad/pull/33)]
+
 ## [0.4.0] - 2022-07-22
 
 ### Adicionado

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -42,4 +42,4 @@ galaxy_info:
 dependencies:
   - name: iac_role_runtime
     src: git+https://github.com/mentoriaiac/iac_role_runtime.git
-    version: v0.1.0
+    version: v0.2.0


### PR DESCRIPTION
No PR #32 a atualização da dependência da role `iac_role_runtime` foi
feita apenas no arquivo `molecule/default/requirements.yml` que é usado
pelo Molecule.

Mas o Ansible Galaxy utiliza o arquivo `meta/main.yml`, então a
dependência precisa ser atualizada nos dois lugares.

Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>
Co-authored-by: Edemir Toldo <edemirtoldo@gmail.com>
Co-authored-by: Jorge Martins <jorge.martins@gmail.com>
Co-authored-by: Luis Kihara <luiskihara@gmail.com>
Co-authored-by: william dias <will.kof1@gmail.com>
Co-authored-by: Danilo F Rocha <snifbr@gmail.com>
Co-authored-by: Donato Horn <donatohorn@gmail.com>

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Corrigir a atualização da role `iac_role_runtime`.

## Referências

- https://github.com/ansible-community/molecule/issues/1321

## Como testar

Como o Molecule lê a dependência de um outro arquivo, os testes irão sempre passar. Para validar é preciso comparar os arquivos `molecule/default/requirements.yml` e `meta/main.yml` e verificar que são iguais:

```console
$ yq '.' molecule/default/requirements.yml
[
  {
    "name": "iac_role_runtime",
    "src": "git+https://github.com/mentoriaiac/iac_role_runtime.git",
    "version": "v0.2.0"
  }
]

$ yq '.dependencies' meta/main.yml
[
  {
    "name": "iac_role_runtime",
    "src": "git+https://github.com/mentoriaiac/iac_role_runtime.git",
    "version": "v0.2.0"
  }
]
```